### PR TITLE
#34 fix of problem with importing `pip._internal.main` as `pip_exec`

### DIFF
--- a/pundle.py
+++ b/pundle.py
@@ -53,6 +53,10 @@ try:
     from pip import main as pip_exec
 except ImportError:
     from pip._internal import main as pip_exec
+    from types import ModuleType
+
+    if isinstance(pip_exec, ModuleType):
+        pip_exec = pip_exec.main
 
 # TODO bundle own version of distlib. Perhaps
 try:


### PR DESCRIPTION
I described my problem in the [issue](https://github.com/Deepwalker/pundler/issues/34). I hope you will accept it!